### PR TITLE
use AbortController instead of AbortSignal to avoid unhandled exception

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -22,13 +22,23 @@ export default class HTTP {
      * @returns {Promise<Pick<import('undici').Dispatcher.ResponseData, 'statusCode' | 'headers' | 'body'>>}
      */
     async request(url, options) {
-        const { statusCode, headers, body } = await this.requestFn(
-            new URL(url),
-            {
-                ...options,
-                signal: AbortSignal.timeout(options.timeout || 1000),
-            },
-        );
-        return { statusCode, headers, body };
+        const abortController = new AbortController();
+
+        const timeoutId = setTimeout(() => {
+            abortController.abort();
+        }, options.timeout || 1000);
+
+        try {
+            const { statusCode, headers, body } = await this.requestFn(
+                new URL(url),
+                {
+                    ...options,
+                    signal: abortController.signal,
+                },
+            );
+            return { statusCode, headers, body };
+        } finally {
+            clearTimeout(timeoutId);
+        }
     }
 }


### PR DESCRIPTION
With this PR, we replace `AbortSignal.timeout()` with the more general `AbortController.abort()` in combination with `setTimeout`. This change prevents an unhandled exception propagating up outside the scope of the calling function.

Fixes https://github.com/podium-lib/client/issues/411